### PR TITLE
Fix metadata storing, add a 'force download' option, and some docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A command-line interface to [Flickr](https://www.flickr.com/). Upload and downlo
 	
 	or
 	
-		composer install
+		composer install --no-dev
 
 3. Go to <https://www.flickr.com/services/apps/create/apply/> to create a new API key.
 The first time you run `./application.php auth` you'll be prompted to enter your new consumer key and secret.


### PR DESCRIPTION
This updates some documentation, refactors the base execute() method
of the Download command, fixes the URL of the original file that's
downloaded, prevents display of a progress bar if we don't know the
full size of the photo, avoids the non-existant fileNameCountup()
function, and introduces a new 'force' option that will re-download
a photo even if it already exists locally.

Refs #10