### PR TITLE
New CLI option for 'move-after-upload'

### DIFF
--- a/src/TheFox/FlickrCli/Command/AuthCommand.php
+++ b/src/TheFox/FlickrCli/Command/AuthCommand.php
@@ -54,10 +54,6 @@ class AuthCommand extends Command{
 					'consumer_key' => $io->ask('Consumer key:'),
 					'consumer_secret' => $io->ask('Consumer secret:'),
 				),
-				'upload' => array(
-					'move_on_success' => true,
-					'uploaded_dir' => 'uploaded',
-				),
 			);
 			
 			$filesystem->touch($this->configPath);


### PR DESCRIPTION
This adds the --move (or -m) option for providing a destination
directory for uploaded files to be moved to after upload. It
removes this option from the config file (and so is a non-BC
change).

If --move is not specified, the current default behaviour of not
moving files is retained.