### PR TITLE
New import command for Piwigo

### DIFF
--- a/application.php
+++ b/application.php
@@ -5,6 +5,7 @@ require_once __DIR__ . '/vendor/autoload.php';
 
 use Symfony\Component\Console\Application;
 
+use TheFox\FlickrCli\Command\PiwigoCommand;
 use TheFox\FlickrCli\FlickrCli;
 use TheFox\FlickrCli\Command\AlbumsCommand;
 use TheFox\FlickrCli\Command\AuthCommand;
@@ -20,4 +21,5 @@ $application->add(new DeleteCommand());
 $application->add(new DownloadCommand());
 $application->add(new FilesCommand());
 $application->add(new UploadCommand());
+$application->add(new PiwigoCommand());
 $application->run();

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,8 @@
         "guzzlehttp/guzzle": "^3.8",
         "lusitanian/oauth": "^0.2",
         "rych/bytesize": "^1.0",
-        "nesbot/carbon": "^1.21"
+        "nesbot/carbon": "^1.21",
+        "doctrine/dbal": "^2.5"
     },
     "require-dev": {
         "phpstan/phpstan": "^0.7",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,478 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "70302b8e6936d1fadeef0e0bc0866528",
+    "content-hash": "ed8a49f7f09ff32c0bdb5d9e2b96f25c",
     "packages": [
+        {
+            "name": "doctrine/annotations",
+            "version": "v1.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/annotations.git",
+                "reference": "54cacc9b81758b14e3ce750f205a393d52339e97"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/annotations/zipball/54cacc9b81758b14e3ce750f205a393d52339e97",
+                "reference": "54cacc9b81758b14e3ce750f205a393d52339e97",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/lexer": "1.*",
+                "php": "^5.6 || ^7.0"
+            },
+            "require-dev": {
+                "doctrine/cache": "1.*",
+                "phpunit/phpunit": "^5.7"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.4.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Common\\Annotations\\": "lib/Doctrine/Common/Annotations"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "Docblock Annotations Parser",
+            "homepage": "http://www.doctrine-project.org",
+            "keywords": [
+                "annotations",
+                "docblock",
+                "parser"
+            ],
+            "time": "2017-02-24T16:22:25+00:00"
+        },
+        {
+            "name": "doctrine/cache",
+            "version": "v1.6.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/cache.git",
+                "reference": "eb152c5100571c7a45470ff2a35095ab3f3b900b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/cache/zipball/eb152c5100571c7a45470ff2a35095ab3f3b900b",
+                "reference": "eb152c5100571c7a45470ff2a35095ab3f3b900b",
+                "shasum": ""
+            },
+            "require": {
+                "php": "~5.5|~7.0"
+            },
+            "conflict": {
+                "doctrine/common": ">2.2,<2.4"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.8|~5.0",
+                "predis/predis": "~1.0",
+                "satooshi/php-coveralls": "~0.6"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.6.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Common\\Cache\\": "lib/Doctrine/Common/Cache"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "Caching library offering an object-oriented API for many cache backends",
+            "homepage": "http://www.doctrine-project.org",
+            "keywords": [
+                "cache",
+                "caching"
+            ],
+            "time": "2017-07-22T12:49:21+00:00"
+        },
+        {
+            "name": "doctrine/collections",
+            "version": "v1.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/collections.git",
+                "reference": "1a4fb7e902202c33cce8c55989b945612943c2ba"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/collections/zipball/1a4fb7e902202c33cce8c55989b945612943c2ba",
+                "reference": "1a4fb7e902202c33cce8c55989b945612943c2ba",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.6 || ^7.0"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "~0.1@dev",
+                "phpunit/phpunit": "^5.7"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Doctrine\\Common\\Collections\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "Collections Abstraction library",
+            "homepage": "http://www.doctrine-project.org",
+            "keywords": [
+                "array",
+                "collections",
+                "iterator"
+            ],
+            "time": "2017-01-03T10:49:41+00:00"
+        },
+        {
+            "name": "doctrine/common",
+            "version": "v2.7.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/common.git",
+                "reference": "4acb8f89626baafede6ee5475bc5844096eba8a9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/common/zipball/4acb8f89626baafede6ee5475bc5844096eba8a9",
+                "reference": "4acb8f89626baafede6ee5475bc5844096eba8a9",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/annotations": "1.*",
+                "doctrine/cache": "1.*",
+                "doctrine/collections": "1.*",
+                "doctrine/inflector": "1.*",
+                "doctrine/lexer": "1.*",
+                "php": "~5.6|~7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^5.4.6"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.7.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Common\\": "lib/Doctrine/Common"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "Common Library for Doctrine projects",
+            "homepage": "http://www.doctrine-project.org",
+            "keywords": [
+                "annotations",
+                "collections",
+                "eventmanager",
+                "persistence",
+                "spl"
+            ],
+            "time": "2017-07-22T08:35:12+00:00"
+        },
+        {
+            "name": "doctrine/dbal",
+            "version": "v2.5.13",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/dbal.git",
+                "reference": "729340d8d1eec8f01bff708e12e449a3415af873"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/dbal/zipball/729340d8d1eec8f01bff708e12e449a3415af873",
+                "reference": "729340d8d1eec8f01bff708e12e449a3415af873",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/common": ">=2.4,<2.8-dev",
+                "php": ">=5.3.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "4.*",
+                "symfony/console": "2.*||^3.0"
+            },
+            "suggest": {
+                "symfony/console": "For helpful console commands such as SQL execution and import of files."
+            },
+            "bin": [
+                "bin/doctrine-dbal"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.5.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Doctrine\\DBAL\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                }
+            ],
+            "description": "Database Abstraction Layer",
+            "homepage": "http://www.doctrine-project.org",
+            "keywords": [
+                "database",
+                "dbal",
+                "persistence",
+                "queryobject"
+            ],
+            "time": "2017-07-22T20:44:48+00:00"
+        },
+        {
+            "name": "doctrine/inflector",
+            "version": "v1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/inflector.git",
+                "reference": "e11d84c6e018beedd929cff5220969a3c6d1d462"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/inflector/zipball/e11d84c6e018beedd929cff5220969a3c6d1d462",
+                "reference": "e11d84c6e018beedd929cff5220969a3c6d1d462",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Common\\Inflector\\": "lib/Doctrine/Common/Inflector"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "Common String Manipulations with regard to casing and singular/plural rules.",
+            "homepage": "http://www.doctrine-project.org",
+            "keywords": [
+                "inflection",
+                "pluralize",
+                "singularize",
+                "string"
+            ],
+            "time": "2017-07-22T12:18:28+00:00"
+        },
+        {
+            "name": "doctrine/lexer",
+            "version": "v1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/lexer.git",
+                "reference": "83893c552fd2045dd78aef794c31e694c37c0b8c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/lexer/zipball/83893c552fd2045dd78aef794c31e694c37c0b8c",
+                "reference": "83893c552fd2045dd78aef794c31e694c37c0b8c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Doctrine\\Common\\Lexer\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "Base library for a lexer that can be used in Top-Down, Recursive Descent Parsers.",
+            "homepage": "http://www.doctrine-project.org",
+            "keywords": [
+                "lexer",
+                "parser"
+            ],
+            "time": "2014-09-09T13:34:57+00:00"
+        },
         {
             "name": "guzzlehttp/guzzle",
             "version": "v3.8.1",
@@ -1392,16 +1862,16 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v3.0.6",
+            "version": "v3.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "0808939f81c1347a3c8a82a5925385a08074b0f1"
+                "reference": "4d4896e553f2094e657fe493506dc37c509d4e2b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/0808939f81c1347a3c8a82a5925385a08074b0f1",
-                "reference": "0808939f81c1347a3c8a82a5925385a08074b0f1",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/4d4896e553f2094e657fe493506dc37c509d4e2b",
+                "reference": "4d4896e553f2094e657fe493506dc37c509d4e2b",
                 "shasum": ""
             },
             "require": {
@@ -1439,7 +1909,7 @@
                 "parser",
                 "php"
             ],
-            "time": "2017-06-28T20:53:48+00:00"
+            "time": "2017-07-28T14:45:09+00:00"
         },
         {
             "name": "phpstan/phpstan",

--- a/src/TheFox/FlickrCli/Command/PiwigoCommand.php
+++ b/src/TheFox/FlickrCli/Command/PiwigoCommand.php
@@ -1,0 +1,226 @@
+<?php
+
+namespace TheFox\FlickrCli\Command;
+
+use Doctrine\DBAL\Configuration;
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\DriverManager;
+use Exception;
+use Rezzza\Flickr\ApiFactory;
+use Rezzza\Flickr\Http\GuzzleAdapter;
+use Rezzza\Flickr\Metadata;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Yaml\Yaml;
+
+class PiwigoCommand extends Command
+{
+
+    /** @var string[] Array of photoset titles, keyed by their ID. */
+    protected $photosets;
+
+    protected function configure()
+    {
+        $this->setName('piwigo');
+        $this->setDescription('Upload files from Piwigo to Flickr');
+
+        $this->addOption('config', 'c', InputOption::VALUE_OPTIONAL, 'Path to config file; default: config.yml');
+        $this->addOption('log', 'l', InputOption::VALUE_OPTIONAL, 'Path to log directory; default: log');
+
+        $this->addOption('piwigo-uploads', null, InputOption::VALUE_REQUIRED, "Path to the Piwigo 'uploads' directory");
+    }
+
+    /**
+     * Executes the current command.
+     *
+     * @param InputInterface  $input  An InputInterface instance
+     * @param OutputInterface $output An OutputInterface instance
+     *
+     * @return null|int null or 0 if everything went fine, or an error code
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $config = Yaml::parse('config.yml');
+
+        // Piwigo.
+        if (!isset($config['piwigo'])
+            || !isset($config['piwigo']['dbname'])
+            || !isset($config['piwigo']['dbuser'])
+            || !isset($config['piwigo']['dbpass'])
+            || !isset($config['piwigo']['dbhost'])
+        ) {
+            $output->writeln(
+                "<error>Please set the all of the following options in the 'piwigo' section of config.yml:\n"
+                . "dbname, dbuser, dbpass, & dbhost.</error>"
+            );
+            return 1;
+        }
+        $dbConfig = new Configuration();
+        $connectionParams = array(
+            'dbname' => $config['piwigo']['dbname'],
+            'user' => $config['piwigo']['dbuser'],
+            'password' => $config['piwigo']['dbpass'],
+            'host' => $config['piwigo']['dbhost'],
+            'driver' => 'pdo_mysql',
+        );
+        $conn = DriverManager::getConnection($connectionParams, $dbConfig);
+        $count = $conn->query("SELECT COUNT(*) AS count FROM images")->fetchColumn();
+        $output->writeln(number_format($count)." images found in the Piwigo database");
+        $piwigoUploadsPath = $input->getOption('piwigo-uploads');
+
+        // Flickr.
+        $metadata = new Metadata($config['flickr']['consumer_key'], $config['flickr']['consumer_secret']);
+        $metadata->setOauthAccess($config['flickr']['token'], $config['flickr']['token_secret']);
+        $guzzleAdapterVerbose = new GuzzleAdapter();
+        $apiFactory = new ApiFactory($metadata, $guzzleAdapterVerbose);
+
+        // Photos.
+        $images = $conn->query("SELECT * FROM images")->fetchAll();
+        foreach ($images as $image) {
+            $this->processOne($image, $piwigoUploadsPath, $conn, $output, $apiFactory);
+        }
+    }
+
+    protected function processOne(
+        $image,
+        $piwigoUploadsPath,
+        Connection $conn,
+        OutputInterface $output,
+        ApiFactory $apiFactory
+    ) {
+        // Check file.
+        $filePath = $piwigoUploadsPath.substr($image['path'], 9);
+        if (!file_exists($filePath)) {
+            throw new Exception("File not found: $filePath");
+        }
+
+        // Figure out the privacy level.
+        //   1 = Contacts
+        //   2 = Friends
+        //   4 = Family
+        //   8 = Admins
+        $isPublic = false;
+        $isFriend = false;
+        $isFamily = false;
+        switch ($image['level']) {
+            case 0:
+                $isPublic = true;
+                break;
+            case 1:
+            case 2:
+            case 4:
+                $isFriend = true;
+                $isFamily = true;
+                break;
+            case 8:
+            default:
+                break;
+        }
+
+        // Get tags (including a checksum machine tag).
+        $cats = $conn->prepare("SELECT t.name FROM image_tag it JOIN tags t ON it.tag_id=t.id WHERE it.image_id=:id");
+        $cats->bindValue('id', $image['id']);
+        $cats->execute();
+        $md5sum = !empty($image['md5sum']) ? $image['md5sum'] : md5_file($filePath);
+        $tags = ['checksum:md5='.$md5sum];
+        while ($cat = $cats->fetch()) {
+            $tags[] = $cat['name'];
+        }
+
+        // Make sure it's not already on Flickr (by MD5 checksum only).
+        $md5search = $apiFactory->call('flickr.photos.search', [
+            'user_id' => 'me',
+            'tags' => "checksum:md5=$md5sum",
+        ]);
+        if (((int)$md5search->photos['total']) > 0) {
+            $output->writeln('Already exists: '.$image['name']);
+            return;
+        }
+
+        // Upload to Flickr.
+        $output->write("Uploading: ".$image['name']);
+        $comment = $image['comment'];
+        $xml = $apiFactory->upload($filePath, $image['name'], $comment, $tags, $isPublic, $isFriend, $isFamily);
+        $photoId = isset($xml->photoid) ? (int)$xml->photoid : 0;
+        $stat = isset($xml->attributes()->stat) ? strtolower((string)$xml->attributes()->stat) : '';
+        $successful = $stat == 'ok' && $photoId != 0;
+        if (!$successful) {
+            throw new Exception("Failed to upload $filePath to ".$image['name']);
+        }
+
+        // Add to albums (categories, in Piwigo parlance).
+        $output->write(' [photosets]');
+        $sql = "SELECT c.name FROM image_category ic JOIN categories c ON ic.category_id=c.id WHERE ic.image_id=:id";
+        $cats = $conn->prepare($sql);
+        $cats->bindValue('id', $image['id']);
+        $cats->execute();
+        while ($cat = $cats->fetch()) {
+            $photosetId = $this->getPhotosetId($apiFactory, $cat['name'], $photoId, $output);
+            $apiFactory->call('flickr.photosets.addPhoto', [
+                'photoset_id' => $photosetId,
+                'photo_id' => $photoId,
+            ]);
+        }
+
+        // Add to an import photoset.
+        $importFromPiwigoId = $this->getPhotosetId($apiFactory, 'Imported from Piwigo', $photoId, $output);
+        $apiFactory->call('flickr.photosets.addPhoto', [
+            'photoset_id' => $importFromPiwigoId,
+            'photo_id' => $photoId,
+        ]);
+
+        // Set location on Flickr.
+        if (!empty($image['latitude']) && !empty($image['longitude'])) {
+            $output->write(' [location]');
+            $apiFactory->call('flickr.photos.geo.setLocation', [
+                'photo_id' => $photoId,
+                'lat' => $image['latitude'],
+                'lon' => $image['longitude'],
+            ]);
+        } else {
+            $output->write(' [no location]');
+        }
+
+        $output->writeln(' -- done');
+    }
+
+    /**
+     * Get a photoset's ID from a name, creating a new photo set if required.
+     * Case insensitive.
+     * @param ApiFactory $apiFactory
+     * @param string $photosetName
+     * @param int $primaryPhotoId
+     * @param OutputInterface $output
+     * @return int
+     */
+    protected function getPhotosetId(ApiFactory $apiFactory, $photosetName, $primaryPhotoId, OutputInterface $output)
+    {
+        // First get all existing albums (once only).
+        if (!is_array($this->photosets)) {
+            $this->photosets = [];
+            $getList = $apiFactory->call('flickr.photosets.getList');
+            foreach ($getList->photosets->photoset as $n => $photoset) {
+                $this->photosets[(int)$photoset->attributes()->id] = (string)$photoset->title;
+            }
+        }
+
+        // See if we've already got it.
+        foreach ($this->photosets as $id => $name) {
+            if (mb_strtolower($photosetName) == mb_strtolower($name)) {
+                return (int)$id;
+            }
+        }
+
+        // Otherwise, create it.
+        $output->write(" [creating new photoset: $photosetName]");
+        $newPhotoset = $apiFactory->call('flickr.photosets.create', array(
+            'title' => $photosetName,
+            'primary_photo_id' => $primaryPhotoId,
+        ));
+        $newId = (int)$newPhotoset->photoset->attributes()->id;
+        $this->photosets[$newId] = $photosetName;
+        return $newId;
+    }
+}


### PR DESCRIPTION
This is a new command for importing images from Piwigo into Flickr.

It creates a new photoset into which to put the imported photos, and takes into account Piwigo tags and categories (photosets).

It adds a machine tag for the MD5 checksum of the file being uploaded. This will make it possible in the future to extend this (and other) commands to check for the existence of a file on Flickr before uploading it.