### PR TITLE
Display an error message if upload fails

### DIFF
--- a/src/TheFox/FlickrCli/Command/UploadCommand.php
+++ b/src/TheFox/FlickrCli/Command/UploadCommand.php
@@ -297,6 +297,10 @@ class UploadCommand extends FlickrCliCommand
                     $photoId = isset($xml->photoid) ? (int)$xml->photoid : 0;
                     $stat = isset($xml->attributes()->stat) ? strtolower((string)$xml->attributes()->stat) : '';
                     $successful = $stat == 'ok' && $photoId != 0;
+                    if (!$successful) {
+                        $this->getLogger()->error(sprintf('[file] error %s: %s (%s)',
+                            $xml->err['code'], $xml->err['msg'], $fileName ));
+                    }
                 } else {
                     $photoId = 0;
                     $successful = false;


### PR DESCRIPTION
There was no error message if the endpoint returned a valid SimpleXML object but it contained an error message.  This displays one now (for example, a permissions error).