### PR TITLE
adding file creation and modified date support + more debugging output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ composer.phar
 /log/
 .env
 .idea
+config
+photosets/

--- a/src/TheFox/FlickrCli/Command/DownloadCommand.php
+++ b/src/TheFox/FlickrCli/Command/DownloadCommand.php
@@ -234,19 +234,20 @@ class DownloadCommand extends FlickrCliCommand
                     ]);
                 }
 
-				/** @var $photo SimpleXMLElement */
-				$total_photos = count($xmlPhotoList->photoset->photo);
-				$current_photo = 0;
+                /** @var $photo SimpleXMLElement */
+                $totalPhotos = count($xmlPhotoList->photoset->photo);
+                $currentPhoto = 0;
                 foreach ($xmlPhotoList->photoset->photo as $photo) {
-					$current_photo++;
+                    $currentPhoto++;
                     pcntl_signal_dispatch();
                     if ($this->getExit()) {
                         break;
                     }
 
-					$this->getLogger()->debug(sprintf('[media] %d/%d photo %s', $page, $fileCount, $photo['id']));
-					$debug_info = " $current_photo/$total_photos at the page $page/$xmlPhotoListPagesTotal - photo set: $photosetTitle";
-                    $downloaded = $this->downloadPhoto($photo, $destinationPath, null, $debug_info);
+                    $this->getLogger()->debug(sprintf('[media] %d/%d photo %s', $page, $fileCount, $photo['id']));
+                    $debugInfo = " $currentPhoto/$totalPhotos at the page $page/$xmlPhotoListPagesTotal "
+                        . "- photo set: $photosetTitle";
+                    $downloaded = $this->downloadPhoto($photo, $destinationPath, null, $debugInfo);
                     if ($downloaded && isset($downloaded->filesize)) {
                         $totalDownloaded += $downloaded->filesize;
                     }
@@ -279,7 +280,8 @@ class DownloadCommand extends FlickrCliCommand
      * @return SimpleXMLElement|boolean Photo metadata as returned by Flickr, or false if something went wrong.
      * @throws Exception
      */
-    private function downloadPhoto(SimpleXMLElement $photo, string $destinationPath, string $basename = null, string $debug_info)
+    private function downloadPhoto(SimpleXMLElement $photo, string $destinationPath, string $basename = null,
+        string $debugInfo)
     {
         $id = (string)$photo->attributes()->id;
 
@@ -420,9 +422,9 @@ class DownloadCommand extends FlickrCliCommand
         }
 
         $this->getLogger()->info(sprintf(
-			"[%s%s] %s, farm %s, server %s, %s, '%s', %s",
-			$media,
-			$debug_info,
+            "[%s%s] %s, farm %s, server %s, %s, '%s', %s",
+            $media,
+            $debugInfo,
             $id,
             $farm,
             $server,
@@ -490,7 +492,7 @@ class DownloadCommand extends FlickrCliCommand
                 );
             } else {
                 // Otherwise, just show the amount downloaded and speed.
-                printf("[file - $debug_info] %s %10s\x1b[0K\r", number_format($downloaded), $downloadedDiffStr);
+                printf("[file$debugInfo] %s %10s\x1b[0K\r", number_format($downloaded), $downloadedDiffStr);
             }
         }
         fclose($fh);
@@ -510,13 +512,13 @@ class DownloadCommand extends FlickrCliCommand
             $xmlPhoto->photo->filesize = $size;
 
             /** @var SimpleXMLElement $photo */
-			$photo = $xmlPhoto->photo;
-			
-			// update the timstamps of the file
-			$update_date = (int) $photo->dates['lastupdate'];
-			$taken_date = strtotime((string) $photo->dates['taken']);
-			touch($filePath, $taken_date, $update_date);
-			// var_dump($taken_date); exit;
+            $photo = $xmlPhoto->photo;
+            
+            // update the timstamps of the file
+            $update_date = (int) $photo->dates['lastupdate'];
+            $taken_date = strtotime((string) $photo->dates['taken']);
+            touch($filePath, $taken_date, $update_date);
+            // var_dump($taken_date); exit;
 
             return $photo;
         }
@@ -596,7 +598,8 @@ class DownloadCommand extends FlickrCliCommand
     {
         $id = $photo['id'];
         $idHash = md5($id);
-        $destinationPath = sprintf('%s/%s/%s/%s/%s/%s', $this->destinationPath, $idHash[0], $idHash[1], $idHash[2], $idHash[3], $id);
+        $destinationPath = sprintf('%s/%s/%s/%s/%s/%s', $this->destinationPath, $idHash[0], $idHash[1], 
+            $idHash[2], $idHash[3], $id);
 
         $filesystem = new Filesystem();
         if (!$filesystem->exists($destinationPath)) {

--- a/src/TheFox/FlickrCli/Command/DownloadCommand.php
+++ b/src/TheFox/FlickrCli/Command/DownloadCommand.php
@@ -280,9 +280,12 @@ class DownloadCommand extends FlickrCliCommand
      * @return SimpleXMLElement|boolean Photo metadata as returned by Flickr, or false if something went wrong.
      * @throws Exception
      */
-    private function downloadPhoto(SimpleXMLElement $photo, string $destinationPath, string $basename = null,
-        string $debugInfo)
-    {
+    private function downloadPhoto(
+        SimpleXMLElement $photo, 
+        string $destinationPath, 
+        string $basename = null,
+        string $debugInfo
+    ) {
         $id = (string)$photo->attributes()->id;
 
         $apiFactory = $this->getApiService()->getApiFactory();
@@ -598,8 +601,15 @@ class DownloadCommand extends FlickrCliCommand
     {
         $id = $photo['id'];
         $idHash = md5($id);
-        $destinationPath = sprintf('%s/%s/%s/%s/%s/%s', $this->destinationPath, $idHash[0], $idHash[1], 
-            $idHash[2], $idHash[3], $id);
+        $destinationPath = sprintf(
+            '%s/%s/%s/%s/%s/%s', 
+            $this->destinationPath, 
+            $idHash[0], 
+            $idHash[1], 
+            $idHash[2], 
+            $idHash[3], 
+            $id
+        );
 
         $filesystem = new Filesystem();
         if (!$filesystem->exists($destinationPath)) {

--- a/src/TheFox/FlickrCli/Command/DownloadCommand.php
+++ b/src/TheFox/FlickrCli/Command/DownloadCommand.php
@@ -618,7 +618,7 @@ class DownloadCommand extends FlickrCliCommand
 
         // Save the actual file.
         $apiFactory = $this->getApiService()->getApiFactory();
-        $photo = $this->downloadPhoto($photo, $destinationPath, $id);
+        $photo = $this->downloadPhoto($photo, $destinationPath, $id, "");
         if (false === $photo) {
             $this->getLogger()->error(sprintf('Unable to get metadata about photo: %s', $id));
             return;

--- a/src/TheFox/FlickrCli/Command/DownloadCommand.php
+++ b/src/TheFox/FlickrCli/Command/DownloadCommand.php
@@ -602,7 +602,7 @@ class DownloadCommand extends FlickrCliCommand
         $id = $photo['id'];
         $idHash = md5($id);
         $destinationPath = sprintf(
-            '%s/%s/%s/%s/%s/%s', 
+            '%s/%s/%s/%s/%s/%s',
             $this->destinationPath,
             $idHash[0],
             $idHash[1],

--- a/src/TheFox/FlickrCli/Command/DownloadCommand.php
+++ b/src/TheFox/FlickrCli/Command/DownloadCommand.php
@@ -281,8 +281,8 @@ class DownloadCommand extends FlickrCliCommand
      * @throws Exception
      */
     private function downloadPhoto(
-        SimpleXMLElement $photo, 
-        string $destinationPath, 
+        SimpleXMLElement $photo,
+        string $destinationPath,
         string $basename = null,
         string $debugInfo
     ) {
@@ -603,11 +603,11 @@ class DownloadCommand extends FlickrCliCommand
         $idHash = md5($id);
         $destinationPath = sprintf(
             '%s/%s/%s/%s/%s/%s', 
-            $this->destinationPath, 
-            $idHash[0], 
-            $idHash[1], 
-            $idHash[2], 
-            $idHash[3], 
+            $this->destinationPath,
+            $idHash[0],
+            $idHash[1],
+            $idHash[2],
+            $idHash[3],
             $id
         );
 


### PR DESCRIPTION
1) created files were having "now()" to their creation and modified timestamps. used flickr photo meta data to update after file creation on the fs.

2) added photo number, total photos in that page and page indicators aside of the album/photoset currently downloading for better understanding to the progress of the download. Example:

```
[file -  90/500 at the page 1/2 - photo set: Auto Upload] 2,647,529   2.01MB/s
```